### PR TITLE
Include MIT-LICENSE in gem

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,6 @@
-Copyright 2012 YOURNAME
+The MIT License
+
+Copyright (c) 2009 Stephan Maka <stephan@spaceboyz.net> and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/ruby-sasl.gemspec
+++ b/ruby-sasl.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
                               lib/sasl/plain.rb
                               lib/sasl/base64.rb
                               lib/sasl.rb
-                              README.markdown)
+                              README.markdown
+                              MIT-LICENSE)
   s.has_rdoc = false
   s.homepage = 'http://github.com/pyu10055/ruby-sasl/'
   s.require_paths = ["lib"]


### PR DESCRIPTION
This adds the MIT-LICENSE, which should be included with any distribution of the code, to the gemspec.
